### PR TITLE
Remove shinychat dependency

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -12,15 +12,6 @@ html_deps <- function() {
       src = "www",
       package = "predictive",
       stylesheet = "style.css"
-    ),
-    # Tool calling UI dependencies from shinychat
-    htmltools::htmlDependency(
-      "shinychat-tools",
-      utils::packageVersion("shinychat"),
-      src = "tools",
-      package = "shinychat",
-      stylesheet = "tool-request.css",
-      script = "tool-request.js"
     )
   )
 }


### PR DESCRIPTION
The relevant files are now included with `chat_ui()`, so no more need for this